### PR TITLE
IndexError thrown when finishing the annotation

### DIFF
--- a/pigeon/annotate.py
+++ b/pigeon/annotate.py
@@ -53,9 +53,13 @@ def annotate(examples,
         nonlocal current_index
         current_index += 1
         set_label_text()
-        update_button_style()
+        # If we reach the end, don't update the buttons.
+        if current_index < len(examples):
+            update_button_style()
         if current_index >= len(examples):
             for btn in buttons:
+                if btn.description == 'back':
+                    continue
                 btn.disabled = True
             print('Annotation done.')
             return
@@ -72,6 +76,10 @@ def annotate(examples,
 
     def back(btn):
         nonlocal current_index
+        # If the annotation was finished. Buttons needs to be re-enabled.
+        if current_index >= len(examples):
+            for btn in buttons:
+                btn.disabled = False
         if current_index is not 0:
             current_index-=2
             show_next()


### PR DESCRIPTION
Thank you for introducing a back button !!

* Buttons are not updated when reaching the end of the annotation.
* Buttons are re-enabled when going back from the end.

How to reproduce :
```python
from pigeon import annotate
annotations = annotate(
  ['I love this movie', 'I was really disappointed by the book'],
  options=['positive', 'negative']
)
```